### PR TITLE
invalid @ref in doc repaired

### DIFF
--- a/src/traversals/BFS/bfs_par.jl
+++ b/src/traversals/BFS/bfs_par.jl
@@ -3,7 +3,7 @@
 
 Run a parallel BFS traversal on a graph and return the parent vertices of each vertex in the BFS tree in the given 'parents' Array.
 
-See also: [bfs_par_tree](@ref)
+See also: [bfs_par](@ref)
 """
 function bfs_par!(
     graph::AbstractGraph, source::T, parents::Array{Atomic{T}}
@@ -38,7 +38,7 @@ end
 
 Run a parallel BFS traversal on a graph and return the parent vertices of each vertex in the BFS tree in a new Array.
 
-See also: [bfs_par_tree!](@ref)
+See also: [bfs_par!](@ref)
 """
 function bfs_par(graph::AbstractGraph, source::T) where {T<:Integer}
     #parents = Array{Atomic{T}}(0, nv(graph))

--- a/src/traversals/BFS/bfs_seq.jl
+++ b/src/traversals/BFS/bfs_seq.jl
@@ -3,7 +3,7 @@
 
 Run a sequential BFS traversal on a graph and return the parent vertices of each vertex in the BFS tree in the given 'parents' Array.
 
-See also: [bfs_seq_tree](@ref)
+See also: [bfs_seq](@ref)
 """
 function bfs_seq!(graph::AbstractGraph, source::T, parents::Array{T}) where {T<:Integer}
     queue::Vector{T} = Vector{T}(undef, 0) # FIFO of vertices to visit
@@ -30,7 +30,7 @@ end
 
 Run a sequential BFS traversal on a graph and return the parent vertices of each vertex in the BFS tree in a new Array.
 
-See also: [bfs_seq_tree!](@ref)
+See also: [bfs_seq!](@ref)
 """
 function bfs_seq(graph::AbstractGraph, source::T) where {T<:Integer}
     #parents = Array{T} # Set of Parent vertices


### PR DESCRIPTION
Some @ref in the doc-strings had the old method names.
They now have the good names and the doc build correctly